### PR TITLE
Update 20181218135310-betrayalLeague-up.sql

### DIFF
--- a/migrations/sqls/20181218135310-betrayalLeague-up.sql
+++ b/migrations/sqls/20181218135310-betrayalLeague-up.sql
@@ -2,7 +2,7 @@ USE poe_currency;
 
 INSERT INTO leagues (id, name, active, css) VALUES
   (11, 'Betrayal', TRUE, 'betrayal'),
-  (12, 'Betrayal Hardcore', TRUE, 'hardcore-betrayal');
+  (12, 'Hardcore Betrayal', TRUE, 'hardcore-betrayal');
 
 UPDATE leagues SET active = FALSE WHERE id = 9;
 UPDATE leagues SET active = FALSE WHERE id = 10;


### PR DESCRIPTION
BHC was mis-named in migrations.